### PR TITLE
修复二次转码与文件路径保存bug

### DIFF
--- a/aliyun_oss2_storage/backends.py
+++ b/aliyun_oss2_storage/backends.py
@@ -124,6 +124,7 @@ class AliyunBaseStorage(BucketOperationMixin, Storage):
         return AliyunFile(name, self, mode)
 
     def _save(self, name, content):
+        # 为保证django行为的一致性，保存文件时，应该返回相对于`media path`的相对路径。
         target_name = self._get_target_name(name)
 
         content.open()

--- a/aliyun_oss2_storage/backends.py
+++ b/aliyun_oss2_storage/backends.py
@@ -124,11 +124,11 @@ class AliyunBaseStorage(BucketOperationMixin, Storage):
         return AliyunFile(name, self, mode)
 
     def _save(self, name, content):
-        name = self._get_target_name(name)
+        target_name = self._get_target_name(name)
 
         content.open()
         content_str = b''.join(chunk for chunk in content.chunks())
-        self.bucket.put_object(name, content_str)
+        self.bucket.put_object(target_name, content_str)
         content.close()
 
         return self._clean_name(name)
@@ -166,7 +166,9 @@ class AliyunBaseStorage(BucketOperationMixin, Storage):
 
     def url(self, name):
         name = self._normalize_name(self._clean_name(name))
-        name = filepath_to_uri(name)
+        # name = filepath_to_uri(name) # 这段会导致二次encode
+        name = name.encode('utf8') 
+        # 做这个转化，是因为下面的_make_url会用urllib.quote转码，转码不支持unicode，会报错，在python2环境下。
         return self.bucket._make_url(self.bucket_name, name)
 
     def read(self, name):


### PR DESCRIPTION
1. 修复二次转码问题
2. 修复media文件在django下能正确保存，但不能正确取出的问题（原因是django内部定义media路径时，不应该在image fileds字段写入media的路径，应该写相对路径，但原程序中写绝对路径了。这样导致在取出路径字段时，media路径重复了两次）
