### PR TITLE
Fix encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import find_packages, setup
 
-with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
+with open(os.path.join(os.path.dirname(__file__), 'README.md'), encoding='utf-8') as readme:
     README = readme.read()
 
 # allow setup.py to be run from any path


### PR DESCRIPTION
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 55: ordinal not in range(128)